### PR TITLE
enable CONFIG_PCSC

### DIFF
--- a/wpa_supplicant/android.config
+++ b/wpa_supplicant/android.config
@@ -219,7 +219,7 @@ CONFIG_SMARTCARD=y
 
 # PC/SC interface for smartcards (USIM, GSM SIM)
 # Enable this if EAP-SIM or EAP-AKA is included
-#CONFIG_PCSC=y
+CONFIG_PCSC=y
 
 # Support HT overrides (disable HT/HT40, mask MCS rates, etc.)
 #CONFIG_HT_OVERRIDES=y


### PR DESCRIPTION
try to fix #5203
http://code.google.com/p/cyanogenmod/issues/detail?id=5203

As said in the file, we need config_pcsc if config_eap_sim is enable (and it is).
